### PR TITLE
fixing users payload in BASH shifts bulk

### DIFF
--- a/examples/bash/post/shifts/bulk
+++ b/examples/bash/post/shifts/bulk
@@ -11,7 +11,7 @@ data="
     \"dtend\": \"$3\",
     \"location\": { \"id\": $4 },
     \"position\": { \"id\": $5 },
-    \"user\": { \"id\": $6 }
+    \"users\": [{ \"id\": $6 }]
   }
 ]
 "


### PR DESCRIPTION
Switch BASH example to appropriate `users` parameter instead of `user`